### PR TITLE
Fix for systems with SELinux enabled

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   build:
     image: softprops/lambda-rust
     volumes:
-    - .:/code
-    - ~/.cargo/registry:/root/.cargo/registry
+    - .:/code:Z
+    - ~/.cargo/registry:/root/.cargo/registry:Z
     environment:
     - BIN=lambda


### PR DESCRIPTION
without the :Z the volumes are mounted without correct SELinux data and thus `docker-compose run --rm build` will fail